### PR TITLE
Feat: add bytes amount for detection

### DIFF
--- a/ktuvitManager.js
+++ b/ktuvitManager.js
@@ -375,8 +375,9 @@ class KtuvitManager {
    * @param {string} KtuvitId Title's ktuvit id
    * @param {string} subId The sub's id.
    * @param {function (buffer, err)} cb The callback function
+   * @param {object} extraOpts extra options
    */
-  async downloadSubtitle(KtuvitId, subId, cb) {
+  async downloadSubtitle(KtuvitId, subId, cb, extraOpts) {
     const downloadIdentifierRequest = {
       FilmID: KtuvitId,
       SubtitleID: subId,
@@ -396,7 +397,7 @@ class KtuvitManager {
 
     await superagent
       .get(KtuvitManager.KTUVIT.DOWNLOAD_SUB_URL + downloadIdentifier)
-      .charset("ISO-8859-8")
+      .charset("ISO-8859-8", extraOpts?.bytesAmountForDetection)
       .withCredentials()
       .set(this.headers)
       .buffer(true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ktuvit-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ktuvit-api",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "chardet": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ktuvit-api",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An unofficial JS api for Ktuvit.me (previously screwzira)",
   "main": "ktuvitManager.js",
   "scripts": {


### PR DESCRIPTION
Added a parameter to control how many bytes are needed for detection.

It might solve memory issues that occur when detecting the entire file.

Updated version to 0.4.1.