### PR TITLE
Fix encoding detection for small files and incorrect fallback charset

### DIFF
--- a/detectAndEncodeResponse.js
+++ b/detectAndEncodeResponse.js
@@ -41,7 +41,7 @@ module.exports = function install(superagent) {
         const responseBuffer = Buffer.concat(chunks);
 
         try {
-          if (!bytesAmountForDetection)
+          if (!detectedEncoding)
             detectedEncoding = chardet.detect(responseBuffer);
 
           if (!detectedEncoding) {

--- a/ktuvitManager.js
+++ b/ktuvitManager.js
@@ -397,7 +397,7 @@ class KtuvitManager {
 
     await superagent
       .get(KtuvitManager.KTUVIT.DOWNLOAD_SUB_URL + downloadIdentifier)
-      .charset("ISO-8859-8", extraOpts?.bytesAmountForDetection)
+      .charset("windows-1255", extraOpts?.bytesAmountForDetection)
       .withCredentials()
       .set(this.headers)
       .buffer(true)


### PR DESCRIPTION
Fixes #12

## Changes

### `detectAndEncodeResponse.js`
Changed `if (!bytesAmountForDetection)` → `if (!detectedEncoding)` in the `end` handler.

Previously, when `bytesAmountForDetection=256` and the file was smaller than 256 bytes, chardet never ran during streaming (threshold never crossed) and was also skipped in the `end` handler because the condition checked the option value rather than whether detection had already occurred. The fallback encoding was used blindly.

### `ktuvitManager.js`
Changed fallback encoding from `"ISO-8859-8"` to `"windows-1255"`.

Ktuvit serves subtitle files in Windows-1255. While both encodings share the Hebrew alphabet range (0xE0–0xFA), they differ in 0x80–0x9F where Windows-1255 maps to printable characters (smart quotes, dashes) and ISO-8859-8 maps to C1 control characters — causing U+FFFD replacement characters in the output.

## Test plan
- [ ] Verify subtitle files smaller than 256 bytes decode correctly to UTF-8 Hebrew
- [ ] Verify the full Stremio subtitle proxy chain returns valid WEBVTT
- [ ] Verify punctuation and special characters in Hebrew subtitles render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)