### PR TITLE
fix: skip non-subtitle rows when parsing subtitle list HTML

### DIFF
--- a/ktuvitManager.js
+++ b/ktuvitManager.js
@@ -325,6 +325,13 @@ class KtuvitManager {
       dummyDom.document.getElementById("subtitlesList");
     subtitlesListElement = [...subtitlesListElement.rows];
     subtitlesListElement.shift();
+    // When a title has no subtitles, Ktuvit renders a single placeholder
+    // row (e.g. a colspan'd "אין כתוביות" cell) instead of an empty
+    // fragment. It doesn't have the <div> every real subtitle row has, so
+    // skip anything that doesn't match instead of crashing on it.
+    subtitlesListElement = subtitlesListElement.filter((sub) =>
+      sub.cells[0]?.querySelector("div")
+    );
     // I don't care it's this way, it works.
     // I never learned jquery so don't judge me.
     var subtitlesIDs = subtitlesListElement.map((sub) => {


### PR DESCRIPTION
## Summary
- `extractSubsFromHtml` crashed with `TypeError: Cannot read properties of null (reading 'innerHTML')` whenever a title has zero subtitles on Ktuvit.
- Root cause: for a title with no subtitles, Ktuvit's `GetModuleAjax.ashx?moduleName=SubtitlesList` endpoint returns a single placeholder row (`<td colspan='6'>אין כתוביות</td>`) instead of an empty fragment. The parser assumed every row after the header is a real subtitle row with a `<div>` in the first cell, so it blew up on that placeholder.
- Found via production log analysis on a downstream consumer (ktuvit-stremio): this single crash accounted for ~95% of all logged errors there (53k+ occurrences over 5 days), and reproduced 100% of the time for any title with no subtitles — e.g. one episode failed on all 4,302 of its requests.
- Fix: filter out rows without the expected `<div>` structure before mapping, instead of crashing on them.

## Verification
Reproduced live against ktuvit.me: fetched the raw AJAX response for an episode with no subtitles, confirmed it triggers the exact reported TypeError against the old code, then confirmed the fix returns `[]` for that case while a real subtitle row (also fetched live) still parses correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>